### PR TITLE
Update regex for cloudinary checks to accept other characters

### DIFF
--- a/cloudinary/cloudinary.module
+++ b/cloudinary/cloudinary.module
@@ -922,10 +922,10 @@ function _cloudinary_check_connection() {
     preg_match('#(?<=://)([0-9\.a-z\.A-Z]+)#', $api_env, $match);
     if (isset($match[0])) $key = $match[0];
 
-    preg_match('#(?<=\:)([0-9\.a-z\.A-Z]+)#', $api_env, $match);
+    preg_match('#(?<=\:)([0-9\.a-z\.A-Z\_]+)#', $api_env, $match);
     if (isset($match[0])) $secret = $match[0];
 
-    preg_match('#(?<=@)([0-9\.a-z\.A-Z]+)#', $api_env, $match);
+    preg_match('#(?<=@)([0-9\.a-z\.A-Z\-]+)#', $api_env, $match);
     if (isset($match[0])) $cloud = $match[0];
 
     if (isset($key) && isset($secret) && isset($cloud)) {


### PR DESCRIPTION
Some keys and names can contain underscores or hyphens that can prevent successful authentication checks, updated regex to allow for this in the appropriate places.